### PR TITLE
No-block-stdio for Minecraft handling

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,10 @@ mod network;
 mod system;
 
 use rustyline::error::ReadlineError;
-use std::fs;
+use std::{
+    fs,
+    sync::{Arc, Mutex},
+};
 
 use crate::system::{
     command::{self, CommandManager},
@@ -13,24 +16,29 @@ pub fn run() -> anyhow::Result<()> {
     // Create instances directory if it doesn't exist
     fs::create_dir_all("instances")?;
 
-    let mut cmd_manager = CommandManager::new();
-
-    let mut state = State::default();
-    state.update_server_names(&mut cmd_manager)?; // Update server names for auto-completion
-
+    let cmd_manager = CommandManager::default();
     let mut editor = command::create_editor(cmd_manager)?;
+    let external_printer = Arc::new(Mutex::new(editor.create_external_printer()?));
+    let mut state = State {
+        editor,
+        async_runtime: tokio::runtime::Runtime::new()?,
+        reqwest_client: reqwest::Client::new(),
+        external_printer,
+        selected_server: None,
+        server_names: vec![],
+    };
+
+    state.update_server_names()?; // Update server names for auto-completion
 
     loop {
-        let readline = editor.readline(">> ");
+        let readline = state.editor.readline(">> ");
         match readline {
             Ok(line) => {
                 let line = line.trim();
 
-                editor.add_history_entry(line)?;
+                state.editor.add_history_entry(line)?;
 
-                let cmd_manager = editor.helper_mut().unwrap();
-                cmd_manager
-                    .execute(line, &mut state)
+                CommandManager::execute(line, &mut state)
                     .unwrap_or_else(|e| eprintln!("Error executing command: {e}"));
             }
             Err(ReadlineError::Interrupted) => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,20 +30,14 @@ pub fn run() -> anyhow::Result<()> {
     let mut context = Context::Default;
 
     loop {
+        let readline = state.editor.readline("multi-server> ");
+
         // If the context is updated, we will receive a message from the context channel.
         // In default context, we execute the input command.
         // In Minecraft server context, we write the command to the server's stdin.
         if let Ok(ctx) = state.context_rx.try_recv() {
             context = ctx;
         }
-
-        let readline = match context {
-            Context::Default => state.editor.readline("multi-server> "),
-            Context::MinecraftServer(_) => {
-                let selected_server_name = &state.selected_server.as_ref().unwrap().name;
-                state.editor.readline(&format!("{selected_server_name}> "))
-            }
-        };
 
         match readline {
             Ok(line) => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,19 +28,26 @@ pub fn run() -> anyhow::Result<()> {
     let mut context = Context::Default;
 
     loop {
-        let readline = state.editor.readline(">> ");
+        // If the context is updated, we will receive a message from the context channel.
+        // In default context, we execute the input command.
+        // In Minecraft server context, we write the command to the server's stdin.
+        if let Ok(ctx) = state.context_rx.try_recv() {
+            context = ctx;
+        }
+
+        let readline = match context {
+            Context::Default => state.editor.readline("multi-server> "),
+            Context::MinecraftServer(_) => {
+                let selected_server_name = &state.selected_server.as_ref().unwrap().name;
+                state.editor.readline(&format!("{selected_server_name}> "))
+            }
+        };
+
         match readline {
             Ok(line) => {
                 let line = line.trim();
 
                 state.editor.add_history_entry(line)?;
-
-                // If the context is updated, we will receive a message from the context channel.
-                // In default context, we execute the input command.
-                // In Minecraft server context, we write the command to the server's stdin.
-                if let Ok(ctx) = state.context_rx.try_recv() {
-                    context = ctx;
-                }
 
                 match context {
                     Context::Default => {

--- a/src/system/command.rs
+++ b/src/system/command.rs
@@ -623,7 +623,7 @@ impl<P: ExternalPrinter + Send + Sync + 'static> CommandManager<P> {
     }
 
     fn set_max_memory_handler(state: &mut State<P>, tokens: &[String]) -> Result<(), String> {
-        let max_memory = tokens.get(1).ok_or("No max memory provided.")?;
+        let max_memory = tokens.get(2).ok_or("No max memory provided.")?;
         let selected_server = state
             .selected_server
             .as_mut()
@@ -642,7 +642,7 @@ impl<P: ExternalPrinter + Send + Sync + 'static> CommandManager<P> {
     }
 
     fn set_min_memory_handler(state: &mut State<P>, tokens: &[String]) -> Result<(), String> {
-        let min_memory = tokens.get(1).ok_or("No min memory provided.")?;
+        let min_memory = tokens.get(2).ok_or("No min memory provided.")?;
         let selected_server = state
             .selected_server
             .as_mut()
@@ -989,6 +989,9 @@ impl<P: ExternalPrinter + Send + Sync + 'static> CommandManager<P> {
             printer
                 .print("Server process has exited.\n".to_string())
                 .expect("Failed to print exit message");
+
+            // Reset the current directory
+            env::set_current_dir("../..").expect("Failed to reset current directory");
 
             // Reset the context to default after the server exits
             context_tx.send(crate::Context::Default).unwrap();

--- a/src/system/command.rs
+++ b/src/system/command.rs
@@ -968,12 +968,13 @@ impl<P: ExternalPrinter + Send + Sync + 'static> CommandManager<P> {
         // Thread that reads the server's output and prints
         let printer = state.external_printer.clone();
         let context_tx = state.context_tx.clone();
-        std::thread::spawn(move || {
-            // Send the context to indicate we are in the Minecraft server context
-            context_tx
-                .send(crate::Context::MinecraftServer(writer))
-                .unwrap();
 
+        // Send the context to indicate we are in the Minecraft server context
+        context_tx
+            .send(crate::Context::MinecraftServer(writer))
+            .unwrap();
+
+        std::thread::spawn(move || {
             let mut printer = printer.lock().unwrap();
             for line in reader.lines() {
                 match line {

--- a/src/system/state.rs
+++ b/src/system/state.rs
@@ -22,6 +22,7 @@ use crate::{
 /// Represents the current operating context of multi-server.
 /// Starts as `Default`, switches to `MinecraftServer` when a server is running,
 /// and reverts to `Default` when the server process ends.
+#[derive(Debug)]
 pub enum Context {
     Default,
     MinecraftServer(BufWriter<ChildStdin>),


### PR DESCRIPTION
Fix #18.

This simply use ExternalPrinter for printing Minecraft server's stdout. But there's still difficulties on dynamically changing the prompt message.

Also some code cleanup.