### PR TITLE
Infer server fork when updating server jar. Fix #38

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,7 +11,7 @@ use crate::{
         server_info::ServerInfo,
     },
 };
-use clap::Parser;
+use clap::{CommandFactory, Parser};
 use dialoguer::Confirm;
 use directories::ProjectDirs;
 use reqwest::Client;
@@ -382,8 +382,15 @@ where
 
     // Clap parser needs a dummy program name
     let iter = version_args.into_iter().map(|v| v.into());
-    // TODO: make `update-server-jar` not hard-coded
-    let argv = std::iter::once(OsString::from("mcerv update-server-jar")).chain(iter);
+    let dummy_name = format!(
+        "mcerv {}",
+        Cli::command()
+            .get_matches()
+            .subcommand()
+            .expect("Cannot get subcommand when getting dummy name")
+            .0
+    );
+    let argv = std::iter::once(dummy_name.into()).chain(iter);
     let command = fork.parse_version_args(argv);
 
     let filename = install_from_command(server_name, command, client).await?;

--- a/src/system/cli.rs
+++ b/src/system/cli.rs
@@ -1,6 +1,6 @@
 use crate::{
     network::{fabric_meta, forge_meta, modrinth::SearchIndex, vanilla_meta},
-    system::forks::{FetchCommands, InstallCommands},
+    system::forks::{FetchCommand, InstallCommand},
 };
 use clap::{ArgAction, Args, Parser, Subcommand};
 use reqwest::Client;
@@ -138,11 +138,11 @@ impl Versions for ForgeVersionArgs {
 #[command(version)]
 pub struct Cli {
     #[command(subcommand)]
-    pub command: Commands,
+    pub command: Command,
 }
 
 #[derive(Subcommand)]
-pub enum Commands {
+pub enum Command {
     /// List the installed servers
     LsServers,
     /// List the mods in the target server and check for updates
@@ -161,7 +161,7 @@ pub enum Commands {
     /// List availible versions for the target Minecraft server fork
     Fetch {
         #[command(subcommand)]
-        command: FetchCommands,
+        command: FetchCommand,
     },
     /// Search for a mod with the given name
     SearchMod {
@@ -193,7 +193,7 @@ pub enum Commands {
     /// Install the server with the given versions
     Install {
         #[command(subcommand)]
-        command: InstallCommands,
+        command: InstallCommand,
         server_name: String,
         #[command(flatten)]
         accept_eula: YesArgs,

--- a/src/system/cli.rs
+++ b/src/system/cli.rs
@@ -28,7 +28,7 @@ pub struct YesArgs {
 }
 
 /// Shared vanilla version arguments for Install and UpdateServerJar
-#[derive(Args, Debug)]
+#[derive(Parser, Debug)]
 pub struct VanillaVersionArgs {
     /// Use the latest stable versions (no need to specify versions)
     #[arg(long, action = ArgAction::SetTrue, default_value_t = false, conflicts_with = "version")]
@@ -56,7 +56,7 @@ impl Versions for VanillaVersionArgs {
 }
 
 /// Shared fabric version arguments for Install and UpdateServerJar
-#[derive(Args, Debug)]
+#[derive(Parser, Debug)]
 pub struct FabricVersionArgs {
     /// Use the latest stable versions (no need to specify versions)
     #[arg(long, action = ArgAction::SetTrue, default_value_t = false, conflicts_with_all = ["game_version", "loader_version", "installer_version"])]
@@ -108,7 +108,7 @@ impl Versions for FabricVersionArgs {
 }
 
 /// Shared forge version arguments for Install and UpdateServerJar
-#[derive(Args, Debug)]
+#[derive(Parser, Debug)]
 pub struct ForgeVersionArgs {
     /// Use the latest versions (no need to specify versions)
     #[arg(long, action = ArgAction::SetTrue, default_value_t = false, conflicts_with = "version")]
@@ -208,9 +208,10 @@ pub enum Commands {
     GenStartScript { server_name: String },
     /// Replace the server jar with the specified version
     UpdateServerJar {
-        #[command(subcommand)]
-        command: InstallCommands,
         server_name: String,
+        /// Version arguments specific to the server fork
+        #[arg(allow_hyphen_values = true, trailing_var_arg = true)]
+        version_args: Vec<String>, // This will be parsed at runtime depending on the server fork
     },
     /// Accept the EULA for the target server. This will create or modify the eula.txt file
     AcceptEula { server_name: String },

--- a/src/system/forks.rs
+++ b/src/system/forks.rs
@@ -52,13 +52,13 @@ macro_rules! __define_forks {
 
         use std::ffi::OsString;
         impl ServerFork {
-            pub fn parse_version_args<I, T>(&self, command: I) -> InstallCommands
+            pub fn parse_version_args<I, T>(&self, command: I) -> InstallCommand
             where I: IntoIterator<Item = T>,
                   T: Into<OsString> + Clone
             {
                 match self {
                     $(
-                        ServerFork::$variant => InstallCommands::$variant {
+                        ServerFork::$variant => InstallCommand::$variant {
                                 version_args: <$version_args>::try_parse_from(command).unwrap_or_else(|e| e.exit())
                         },
                     )*
@@ -83,8 +83,7 @@ macro_rules! __define_forks {
         }
 
         #[derive(Subcommand)]
-        pub enum InstallCommands {
-            // TODO: remove the `s` in the enum name
+        pub enum InstallCommand {
             $(
                 $variant {
                     #[command(flatten)]
@@ -94,7 +93,7 @@ macro_rules! __define_forks {
         }
 
         #[derive(Subcommand)]
-        pub enum FetchCommands {
+        pub enum FetchCommand {
             $(
                 $variant {
                     $(

--- a/src/system/forks.rs
+++ b/src/system/forks.rs
@@ -42,8 +42,7 @@ use zip::ZipArchive;
 macro_rules! __define_forks {
     (
         $(
-            // TODO: Rename to version_args
-            $variant:ident => ( $install_args:ty $(,$fetch_filter:ty)? ) ),*
+            $variant:ident => ( $version_args:ty $(,$fetch_filter:ty)? ) ),*
         $(,)?
     ) => {
         #[derive(Debug, Clone, Copy)]
@@ -60,7 +59,7 @@ macro_rules! __define_forks {
                 match self {
                     $(
                         ServerFork::$variant => InstallCommands::$variant {
-                                version_args: <$install_args>::try_parse_from(command).unwrap_or_else(|e| e.exit())
+                                version_args: <$version_args>::try_parse_from(command).unwrap_or_else(|e| e.exit())
                         },
                     )*
                 }
@@ -89,7 +88,7 @@ macro_rules! __define_forks {
             $(
                 $variant {
                     #[command(flatten)]
-                    version_args: $install_args,
+                    version_args: $version_args,
                 },
             )*
         }
@@ -109,9 +108,9 @@ macro_rules! __define_forks {
         // Assert trait implementations by creating and calling anonymous empty generics functions
         $(
             const _: () = {
-                // Check 1: $install_args must implement cli::Versions
+                // Check 1: $version_args must implement cli::Versions
                 const fn assert_is_versions<T: cli::Versions>() {}
-                assert_is_versions::<$install_args>();
+                assert_is_versions::<$version_args>();
 
                 // Check 2: If there is $fetch_filter, it must implement cli::FetchFilter
                 $(


### PR DESCRIPTION
This PR simplify commands
```
mcerv update-server-jar fabric server1 --latest-stable
mcerv update-server-jar vanilla server2 1.20
```
to
```
mcerv update-server-jar server1 --latest-stable
mcerv update-server-jar server2 1.20
```
by parsing version arguments dynamically.

Also fixed some namings.